### PR TITLE
Scope to JS and TS

### DIFF
--- a/generate.mjs
+++ b/generate.mjs
@@ -6,12 +6,20 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const packageJsonPath = path.join(__dirname, "package.json");
 const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
 
-const glimmerTS = ["glimmer-ts", "typescript.glimmer"];
-const glimmerJS = ["glimmer-js", "javascript.glimmer"];
+const glimmerTS = ["typescript", "typescript.glimmer"];
+const glimmerJS = ["javascript", "javascript.glimmer"];
 const glimmer = [...glimmerJS, ...glimmerTS];
 const javascript = ["javascript"];
 const typescript = ["typescript"];
-const allLanguages = [...glimmer, ...javascript, ...typescript];
+const allLanguages = [...glimmer, ...javascript, ...typescript].reduce(
+  (acc, language) => {
+    if (!acc.includes(language)) {
+      acc.push(language);
+    }
+    return acc;
+  },
+  [],
+);
 
 function newSnippet(language, path) {
   return {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "contributes": {
     "snippets": [
       {
-        "language": "glimmer-js",
+        "language": "javascript",
         "path": "./snippets/all.json"
       },
       {
@@ -44,7 +44,7 @@
         "path": "./snippets/all.json"
       },
       {
-        "language": "glimmer-ts",
+        "language": "typescript",
         "path": "./snippets/all.json"
       },
       {
@@ -53,14 +53,6 @@
       },
       {
         "language": "javascript",
-        "path": "./snippets/all.json"
-      },
-      {
-        "language": "typescript",
-        "path": "./snippets/all.json"
-      },
-      {
-        "language": "glimmer-js",
         "path": "./snippets/all-template-tag.json"
       },
       {
@@ -68,7 +60,7 @@
         "path": "./snippets/all-template-tag.json"
       },
       {
-        "language": "glimmer-ts",
+        "language": "typescript",
         "path": "./snippets/all-template-tag.json"
       },
       {
@@ -76,7 +68,7 @@
         "path": "./snippets/all-template-tag.json"
       },
       {
-        "language": "glimmer-js",
+        "language": "javascript",
         "path": "./snippets/javascript.glimmer.json"
       },
       {
@@ -84,7 +76,7 @@
         "path": "./snippets/javascript.glimmer.json"
       },
       {
-        "language": "glimmer-ts",
+        "language": "typescript",
         "path": "./snippets/typescript.glimmer.json"
       },
       {


### PR DESCRIPTION
VSCode determines the language to filter snippets by from the caret position in a file. Inside a GTS or GJS file the outer scope is "typescript" and "javascript" respectively.

Originally tried changing this so the outer scope language was glimmer-ts or glimmer-js but this caused the js/ts language features to never activate for a gts/gjs file.